### PR TITLE
[ftcli fix]: add empty-names subcommand

### DIFF
--- a/foundryToolsCLI/Lib/tables/name.py
+++ b/foundryToolsCLI/Lib/tables/name.py
@@ -168,3 +168,10 @@ class TableName(table__n_a_m_e):
                 name.platEncID,
                 name.langID,
             )
+
+    def remove_empty_names(self):
+        for name in self.names:
+            if str(name).strip() == "":
+                self.removeNames(
+                    nameID=name.nameID, platformID=name.platformID, platEncID=name.platEncID, langID=name.langID
+                )


### PR DESCRIPTION
Fixes fontbakery `com.adobe.fonts/check/name/empty_records` issue