### PR TITLE
Add option to reorganize tool to strip whitespace from foundry name.

### DIFF
--- a/foundryToolsCLI/CLI/ftcli_utils.py
+++ b/foundryToolsCLI/CLI/ftcli_utils.py
@@ -10,17 +10,17 @@ from fontTools.ttLib import TTFont
 from pathvalidate import sanitize_filename, sanitize_filepath
 
 from foundryToolsCLI.Lib.tables.CFF_ import TableCFF
+from foundryToolsCLI.Lib.tables.OS_2 import TableOS2
 from foundryToolsCLI.Lib.tables.head import TableHead
 from foundryToolsCLI.Lib.tables.name import TableName
-from foundryToolsCLI.Lib.tables.OS_2 import TableOS2
 from foundryToolsCLI.Lib.utils.cli_tools import get_fonts_in_path, initial_check_pass
 from foundryToolsCLI.Lib.utils.click_tools import (
-    add_common_options,
     add_file_or_path_argument,
     add_recursive_option,
+    add_common_options,
     choice_to_int_callback,
 )
-from foundryToolsCLI.Lib.utils.logger import Logs, logger
+from foundryToolsCLI.Lib.utils.logger import logger, Logs
 from foundryToolsCLI.Lib.utils.timer import Timer
 
 utils = click.Group("subcommands")

--- a/foundryToolsCLI/CLI/ftcli_utils.py
+++ b/foundryToolsCLI/CLI/ftcli_utils.py
@@ -10,17 +10,17 @@ from fontTools.ttLib import TTFont
 from pathvalidate import sanitize_filename, sanitize_filepath
 
 from foundryToolsCLI.Lib.tables.CFF_ import TableCFF
-from foundryToolsCLI.Lib.tables.OS_2 import TableOS2
 from foundryToolsCLI.Lib.tables.head import TableHead
 from foundryToolsCLI.Lib.tables.name import TableName
+from foundryToolsCLI.Lib.tables.OS_2 import TableOS2
 from foundryToolsCLI.Lib.utils.cli_tools import get_fonts_in_path, initial_check_pass
 from foundryToolsCLI.Lib.utils.click_tools import (
+    add_common_options,
     add_file_or_path_argument,
     add_recursive_option,
-    add_common_options,
     choice_to_int_callback,
 )
-from foundryToolsCLI.Lib.utils.logger import logger, Logs
+from foundryToolsCLI.Lib.utils.logger import Logs, logger
 from foundryToolsCLI.Lib.utils.timer import Timer
 
 utils = click.Group("subcommands")
@@ -145,6 +145,17 @@ def del_table(
     """,
 )
 @click.option(
+    "-s",
+    "--strip",
+    "strip_foundry",
+    is_flag=True,
+    help="""
+    Strip foundry name.
+
+    This option will strip whitespace at the beginning and end of the foundry name before creating the directory.
+    """,
+)
+@click.option(
     "-e",
     "--extension",
     "sort_by_extension",
@@ -163,6 +174,7 @@ def del_table(
 def font_organizer(
     input_path: Path,
     sort_by_foundry: bool = False,
+    strip_foundry: bool = False,
     sort_by_extension: bool = False,
     sort_by_version: bool = False,
 ):
@@ -181,6 +193,7 @@ def font_organizer(
 
             foundry = font.guess_foundry_name() if sort_by_foundry else None
             if foundry:
+                foundry = foundry.strip() if strip_foundry else foundry
                 output_dir = output_dir.joinpath(foundry)
 
             version = f" v{round(font['head'].fontRevision, 3)}" if sort_by_version else None


### PR DESCRIPTION
This adds an option to the reorganize tool to strip whitespace from the foundry names.