### PR TITLE
Add `remove_unreachable_glyphs` command to CLI

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.16
+current_version = 1.1.17
 commit = True
 tag = True
 

--- a/foundryToolsCLI/__init__.py
+++ b/foundryToolsCLI/__init__.py
@@ -1,3 +1,3 @@
-VERSION = __version__ = "1.1.16"
+VERSION = __version__ = "1.1.17"
 
 __all__ = ["VERSION"]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def _get_requirements():
 
 setuptools.setup(
     name="foundrytools-cli",
-    version="1.1.16",
+    version="1.1.17",
     description="A set of command line tools to inspect, manipulate and convert font files",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Introduce a new command to subset font files by removing unreachable glyphs.

Fixes #120 