### PR TITLE
Add file naming for variable fonts and get_axes method

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.17
+current_version = 1.1.18
 commit = True
 tag = True
 

--- a/foundryToolsCLI/Lib/VFont.py
+++ b/foundryToolsCLI/Lib/VFont.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from fontTools.ttLib.tables._f_v_a_r import NamedInstance, Axis
+from fontTools.ttLib.tables._f_v_a_r import NamedInstance
 
 from foundryToolsCLI.Lib.Font import Font
 
@@ -9,9 +9,6 @@ class VariableFont(Font):
     def __init__(self, file=None, recalcTimestamp=False):
         super().__init__(file=file, recalcTimestamp=recalcTimestamp)
         assert "fvar" in self
-
-    def get_axes(self) -> list[Axis]:
-        return [axis for axis in self["fvar"].axes if axis.flags == 0]
 
     def get_instances(self) -> list[NamedInstance]:
         return [instance for instance in self["fvar"].instances]

--- a/foundryToolsCLI/__init__.py
+++ b/foundryToolsCLI/__init__.py
@@ -1,3 +1,3 @@
-VERSION = __version__ = "1.1.17"
+VERSION = __version__ = "1.1.18"
 
 __all__ = ["VERSION"]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def _get_requirements():
 
 setuptools.setup(
     name="foundrytools-cli",
-    version="1.1.17",
+    version="1.1.18",
     description="A set of command line tools to inspect, manipulate and convert font files",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Updated the Font.py to generate filenames for variable fonts based on family name and axes. Moved the get_axes method from VFont.py to Font.py.