### PR TITLE
[vf2i] Allow exporting hidden axes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.18
+current_version = 1.1.19
 commit = True
 tag = True
 

--- a/foundryToolsCLI/CLI/ftcli_converter.py
+++ b/foundryToolsCLI/CLI/ftcli_converter.py
@@ -142,6 +142,15 @@ def otf2ttf(
     """,
 )
 @click.option(
+    "-h",
+    "--hidden-axes",
+    is_flag=True,
+    default=False,
+    help="""
+    Use this option to include hidden axes in the list of available axes.
+    """
+)
+@click.option(
     "--no-cleanup",
     "cleanup",
     is_flag=True,
@@ -166,6 +175,7 @@ def otf2ttf(
 @Timer(logger=logger.info)
 def vf2i(
     input_path: Path,
+    hidden_axes: bool = False,
     select_instance: bool = False,
     cleanup: bool = True,
     update_name_table: bool = True,
@@ -199,7 +209,7 @@ def vf2i(
 
             instances = variable_font.get_instances()
             if select_instance:
-                axes = variable_font.get_axes()
+                axes = variable_font.get_axes(hidden_axes=hidden_axes)
                 selected_coordinates = select_instance_coordinates(axes)
                 is_named_instance = selected_coordinates in [i.coordinates for i in instances]
                 if not is_named_instance:

--- a/foundryToolsCLI/Lib/Font.py
+++ b/foundryToolsCLI/Lib/Font.py
@@ -658,7 +658,7 @@ class Font(TTFont):
         """
         if not self.is_variable:
             return []
-        return [axis for axis in self["fvar"].axes if axis.flags == 0]
+        return [axis for axis in self["fvar"].axes]
 
     def fix_cff_top_dict_version(self) -> None:
         if not self.is_otf:
@@ -736,7 +736,8 @@ class Font(TTFont):
             ui_name_ids = []
             for record in self["GSUB"].table.FeatureList.FeatureRecord:
                 if record.Feature.FeatureParams:
-                    ui_name_ids.append(record.Feature.FeatureParams.UINameID)
+                    if hasattr(record.Feature.FeatureParams, "UINameID"):
+                        ui_name_ids.append(record.Feature.FeatureParams.UINameID)
         return sorted(set(ui_name_ids))
 
     def reorder_ui_name_ids(self) -> None:
@@ -749,14 +750,16 @@ class Font(TTFont):
         if "GSUB" not in self:
             return
         ui_name_ids = self.get_ui_name_ids()
+        if not ui_name_ids:
+            return
         for count, value in enumerate(ui_name_ids, start=256):
             for n in name_table.names:
                 if n.nameID == value:
                     n.nameID = count
             for record in self["GSUB"].table.FeatureList.FeatureRecord:
                 if record.Feature.FeatureParams:
-                    if record.Feature.FeatureParams.UINameID == value:
-                        record.Feature.FeatureParams.UINameID = count
+                    if hasattr(record.Feature.FeatureParams, "UINameID"):
+                        setattr(record.Feature.FeatureParams, "UINameID", count)
 
     def modify_linegap_percent(self, percent):
         """

--- a/foundryToolsCLI/Lib/Font.py
+++ b/foundryToolsCLI/Lib/Font.py
@@ -652,13 +652,16 @@ class Font(TTFont):
         else:
             return Path(self.reader.file.name).stem
 
-    def get_axes(self) -> list[Axis]:
+    def get_axes(self, hidden_axes: bool = False) -> list[Axis]:
         """
         This function returns a list of axes in a variable font.
         """
         if not self.is_variable:
             return []
-        return [axis for axis in self["fvar"].axes]
+        if hidden_axes:
+            return [axis for axis in self["fvar"].axes]
+        else:
+            return [axis for axis in self["fvar"].axes if axis.flags == 0]
 
     def fix_cff_top_dict_version(self) -> None:
         if not self.is_otf:

--- a/foundryToolsCLI/__init__.py
+++ b/foundryToolsCLI/__init__.py
@@ -1,3 +1,3 @@
-VERSION = __version__ = "1.1.18"
+VERSION = __version__ = "1.1.19"
 
 __all__ = ["VERSION"]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def _get_requirements():
 
 setuptools.setup(
     name="foundrytools-cli",
-    version="1.1.18",
+    version="1.1.19",
     description="A set of command line tools to inspect, manipulate and convert font files",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Allow the users to optionally export hidden axes.

### Functionality Enhancements:
* [`foundryToolsCLI/CLI/ftcli_converter.py`](diffhunk://#diff-19498733cd1b56c933333294d1562876e3946daa34b5c82799af7fb10afd8f19R144-R152): Added a new `--hidden-axes` option to include hidden axes in the list of available axes in the `otf2ttf` function.
* [`foundryToolsCLI/Lib/Font.py`](diffhunk://#diff-e62b904ab5464dd21f168d1c8492b404e2e9bfa184d8adaa9ab742ccec3d9760L655-R663): Modified the `get_axes` method to accept a `hidden_axes` parameter, allowing it to return hidden axes if specified.

### Robustness Improvements:
* [`foundryToolsCLI/Lib/Font.py`](diffhunk://#diff-e62b904ab5464dd21f168d1c8492b404e2e9bfa184d8adaa9ab742ccec3d9760R742): Improved the `get_ui_name_ids` and `reorder_ui_name_ids` methods to handle cases where `UINameID` may not be present. [[1]](diffhunk://#diff-e62b904ab5464dd21f168d1c8492b404e2e9bfa184d8adaa9ab742ccec3d9760R742) [[2]](diffhunk://#diff-e62b904ab5464dd21f168d1c8492b404e2e9bfa184d8adaa9ab742ccec3d9760R756-R765)

### Version Increment:
* Updated the version from `1.1.18` to `1.1.19` in multiple files to reflect the new changes. [[1]](diffhunk://#diff-9ea6e1e3dde6d4a7e08c7c88eceed69ca745d0d2c779f8f85219b22266efff7fL2-R2) [[2]](diffhunk://#diff-c72661d036ccc84f9bc0fbb444d803d2f30ea45c6607375df5c80de9ceafe753L1-R1) [[3]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L21-R21)