### PR TITLE
Print hidden axes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.21
+current_version = 1.1.22
 commit = True
 tag = True
 

--- a/foundryToolsCLI/Lib/printer/UI.py
+++ b/foundryToolsCLI/Lib/printer/UI.py
@@ -88,7 +88,7 @@ def print_instances(variable_font: VariableFont):
     instances = variable_font.get_instances()
     table.add_section()
     table.add_column("#")
-    axes = variable_font.get_axes()
+    axes = variable_font.get_axes(hidden_axes=True)
     for axis in axes:
         table.add_column(axis.axisTag)
     table.add_column("subfamilyNameID")

--- a/foundryToolsCLI/__init__.py
+++ b/foundryToolsCLI/__init__.py
@@ -1,3 +1,3 @@
-VERSION = __version__ = "1.1.21"
+VERSION = __version__ = "1.1.22"
 
 __all__ = ["VERSION"]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def _get_requirements():
 
 setuptools.setup(
     name="foundrytools-cli",
-    version="1.1.21",
+    version="1.1.22",
     description="A set of command line tools to inspect, manipulate and convert font files",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
* [`foundryToolsCLI/Lib/printer/UI.py`](diffhunk://#diff-26616286487a03edbaede70c8ba0a45ccc189383023c66b832f2d01bd3f9d981L91-R91): Modified the `print_instances` function to retrieve axes with the `hidden_axes` parameter set to `True`.