### PR TITLE
Refactor BaseCommand

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@
 project = "FoundryTools-CLI"
 copyright = "2025, Cesare Gilento"
 author = "Cesare Gilento"
-release = "2.0.0"
+release = "2.0.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ exclude = [
 ]
 
 [tool.bumpversion]
-current_version = "2.0.0"
+current_version = "2.0.1"
 commit = true
 tag = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ exclude = [
 
 [tool.bumpversion]
 current_version = "2.0.0"
-commit = false
+commit = true
 tag = true
 
 [[tool.bumpversion.files]]

--- a/src/foundrytools_cli/__init__.py
+++ b/src/foundrytools_cli/__init__.py
@@ -1,3 +1,3 @@
-VERSION = __version__ = "2.0.0"
+VERSION = __version__ = "2.0.1"
 
 __all__ = ["VERSION"]

--- a/src/foundrytools_cli/utils/__init__.py
+++ b/src/foundrytools_cli/utils/__init__.py
@@ -54,26 +54,28 @@ class BaseCommand(click.Command):
                 """,
             ),
             click.Option(
-                ["-no-rbb", "--no-recalc-bboxes", "recalc_bboxes"],
+                ["-rbb", "--recalc-bboxes", "recalc_bboxes"],
                 is_flag=True,
-                default=True,
+                default=False,
                 help="""
-                Do not recalculate the font's bounding boxes on save.
+                Recalculate the font's bounding boxes on save.
 
                 By default, ``glyf``, ``CFF ``, ``head`` bounding box values and ``hhea``/``vhea``
-                min/max values are recalculated on save. Also, the glyphs are compiled on importing,
-                which saves memory consumption and time.
+                min/max values are not recalculated on save.
+
+                When this option is active, the glyphs are compiled on importing, which saves memory
+                consumption and time.
                 """,
             ),
             click.Option(
-                ["-no-rtb", "--no-reorder-tables", "reorder_tables"],
+                ["-rtb", "--reorder-tables", "reorder_tables"],
                 is_flag=True,
-                default=True,
+                default=False,
                 help="""
-                Do not reorder the font's tables on save.
+                Reorder the font's tables on save.
 
-                By default, tables are sorted by tag on save (recommended by the OpenType
-                specification).
+                When this option is active, tables are sorted by tag on save (recommended by the
+                OpenType specification).
                 """,
             ),
             click.Option(


### PR DESCRIPTION
This pull request modifies options in the `src/foundrytools_cli/utils/__init__.py` file to adjust default behaviors. The changes focus on the `--recalc-bboxes` and `--reorder-tables` flags.

Fixes https://github.com/ftCLI/FoundryTools-CLI/issues/245

### Changes to CLI options:

* Updated `--recalc-bboxes` flag:
  - Changed the short flag from `-no-rbb` to `-rbb`.
  - Modified the default behavior from `True` to `False`, meaning bounding boxes are not recalculated by default.
  - Updated the help text to reflect the new default and clarify the behavior.

* Updated `--reorder-tables` flag:
  - Changed the short flag from `-no-rtb` to `-rtb`.
  - Modified the default behavior from `True` to `False`, meaning tables are not reordered by default.
  - Updated the help text to reflect the new default and clarify the behavior.