### PR TITLE
Version 2.0.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[dev]"
+        pip install -r requirements-dev.txt
+        pip install -e "."
     - name: Analysing the code with mypy
       run: |
         mypy $(git ls-files '*.py' | grep -v "docs/")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@
 project = "FoundryTools-CLI"
 copyright = "2025, Cesare Gilento"
 author = "Cesare Gilento"
-release = "2.0.1"
+release = "2.0.2"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ exclude = [
 ]
 
 [tool.bumpversion]
-current_version = "2.0.1"
+current_version = "2.0.2"
 commit = true
 tag = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,19 +45,6 @@ ftcli = "foundrytools_cli.__main__:cli"
 [project.urls]
 Homepage = "https://github.com/ftCLI/FoundryTools-CLI"
 
-[project.optional-dependencies]
-dev = [
-    "bump-my-version>=1.1.2",
-    "hatch>=1.14.1",
-    "mypy>=1.15.0",
-    "pre-commit>=4.2.0",
-    "pylint>=3.3.6",
-]
-docs = [
-    "sphinx-click>=6.0.0",
-    "sphinx-rtd-theme>=3.0.2",
-]
-
 [tool.hatch.version]
 path = "src/foundrytools_cli/__init__.py"
 pattern = 'VERSION = __version__ = "(?P<version>[^"]+)"'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+bump-my-version>=1.1.2
+hatch>=1.14.1
+mypy>=1.15.0
+pre-commit>=4.2.0
+pylint>=3.3.6

--- a/src/foundrytools_cli/__init__.py
+++ b/src/foundrytools_cli/__init__.py
@@ -1,3 +1,3 @@
-VERSION = __version__ = "2.0.1"
+VERSION = __version__ = "2.0.2"
 
 __all__ = ["VERSION"]

--- a/src/foundrytools_cli/utils/__init__.py
+++ b/src/foundrytools_cli/utils/__init__.py
@@ -54,17 +54,15 @@ class BaseCommand(click.Command):
                 """,
             ),
             click.Option(
-                ["-rbb", "--recalc-bboxes", "recalc_bboxes"],
+                ["-no-rbb", "--no-recalc-bboxes", "recalc_bboxes"],
                 is_flag=True,
-                default=False,
+                default=True,
                 help="""
-                Recalculate the font's bounding boxes on save.
+                Do not recalculate the font's bounding boxes on save.
 
                 By default, ``glyf``, ``CFF ``, ``head`` bounding box values and ``hhea``/``vhea``
-                min/max values are not recalculated on save.
-
-                When this option is active, the glyphs are compiled on importing, which saves memory
-                consumption and time.
+                min/max values are recalculated on save. Also, the glyphs are compiled on importing,
+                which saves memory consumption and time.
                 """,
             ),
             click.Option(

--- a/src/foundrytools_cli/utils/task_runner.py
+++ b/src/foundrytools_cli/utils/task_runner.py
@@ -194,6 +194,6 @@ class TaskRunner:  # pylint: disable=too-few-public-methods
     @staticmethod
     def _log_error(e: Exception) -> None:
         if hasattr(e, "__module__"):
-            logger.opt(colors=True).error(f"<lr>{e.__module__}.{type(e).__name__}</lr>: {e}")
+            logger.opt(colors=True).exception(f"<lr>{e.__module__}.{type(e).__name__}</lr>: {e}")
         else:
-            logger.opt(colors=True).error(f"<lr>{type(e).__name__}</lr>: {e}")
+            logger.opt(colors=True).exception(f"<lr>{type(e).__name__}</lr>: {e}")


### PR DESCRIPTION
This pull request includes several updates to dependency management, versioning, and functionality improvements in the `FoundryTools-CLI` project. The key changes involve switching to a `requirements-dev.txt` file for development dependencies, updating the project version to `2.0.2`, modifying CLI options, and improving error logging.

### Dependency Management Updates:
* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L20-R21): Replaced installation of development dependencies using `pip install -e ".[dev]"` with `pip install -r requirements-dev.txt` for better dependency management.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L48-L60): Removed `project.optional-dependencies` for `dev` and `docs` in favor of using `requirements-dev.txt`.
* [`requirements-dev.txt`](diffhunk://#diff-2b4945591edfeaa4cf4d3f155e66d4b43d1bda7a55d881d5cf3107f1b05abbbcR1-R5): Added a new file listing development dependencies (`bump-my-version`, `hatch`, `mypy`, `pre-commit`, `pylint`).

### CLI Option Improvements:
* [`src/foundrytools_cli/utils/__init__.py`](diffhunk://#diff-c2da46d9d5d95d10effc1e2de7c888528c78a5b0db7551ba5e15833e7f1492eeL57-R65): Changed the `--recalc-bboxes` CLI option to `--no-recalc-bboxes`, updated its default value to `True`, and revised the help text to reflect the new behavior. This was necessary because some commands failed without recalculating bounding boxes.

### Logging Enhancements:
* [`src/foundrytools_cli/utils/task_runner.py`](diffhunk://#diff-05a5a570fdd546d2dc8fb8456a459b152915cad47f0d6b6548eb56f923bfeb55L197-R199): Replaced `logger.error` with `logger.exception` to include stack traces in error logs for better debugging.