### PR TITLE
Add overwrite flag to font renamer and disable overwriting by default

### DIFF
--- a/src/foundrytools_cli/commands/utils/cli.py
+++ b/src/foundrytools_cli/commands/utils/cli.py
@@ -54,6 +54,16 @@ cli = click.Group(help="Miscellaneous utilities.")
         5: CFF TopDict FullName (CFF fonts only)
         """,
 )
+@click.option(
+    "-o",
+    "--overwrite",
+    "overwrite",
+    is_flag=True,
+    help="""
+        Allow overwriting output files. THIS MIGHT POTENTIALLY RESULT IN LOSS OF FILES.
+        USE WITH CARE.
+    """,
+)
 @recursive_flag()
 def font_renamer(input_path: Path, **options: dict[str, Any]) -> None:
     """

--- a/src/foundrytools_cli/commands/utils/font_renamer.py
+++ b/src/foundrytools_cli/commands/utils/font_renamer.py
@@ -54,7 +54,7 @@ def _get_file_stem(font: Font, source: int = 1) -> str:
     return sanitize_filename(file_name, platform="auto")
 
 
-def main(font: Font, source: int = 1) -> None:
+def main(font: Font, source: int = 1, overwrite: bool = False) -> None:
     """
     Renames the given font files.
     """
@@ -71,7 +71,7 @@ def main(font: Font, source: int = 1) -> None:
         file=Path(new_file_name),
         extension=font.get_file_ext(),
         output_dir=old_file.parent,
-        overwrite=True,
+        overwrite=overwrite,
     )
     if new_file == old_file:
         logger.skip(f"{old_file.name} is already named correctly")  # type: ignore


### PR DESCRIPTION
This re-adds the overwrite flag and changes the default behaviour to not overwriting files. This solves #260.